### PR TITLE
enpitsu: docker: Hapus `VIRTUAL_HOST` dan `LETSENCRYPT_HOST`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,8 +32,6 @@ services:
     image: rmecha/enpitsu:main
     restart: always
     environment:
-      VIRTUAL_HOST: ${ENPITSU_VIRTUAL_HOST}
-      LETSENCRYPT_HOST: ${ENPITSU_VIRTUAL_HOST}
       DATABASE_URL: postgresql://enpitsu:enpitsu@db:5432/enpitsu
       REDIS_URL: redis://:enpitsu@cache:6379/4
       AUTH_URL: https://${ENPITSU_VIRTUAL_HOST}


### PR DESCRIPTION
Enpitsu akan menggunakan NGINX Proxy Manager (NPM, bukan NodeJS Package Manager) sebagai pengelola reverse proxy NGINX.

Perpindahan ini memungkinkan konfigurasi yang lebih sederhana dan fleksibel.

`ENPITSU_VIRTUAL_HOST` akan tetap digunakan untuk `AUTH_URL` internal Enpitsu.