### PR TITLE
enpitsu: docker: Tambah layanan Chibisafe

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,6 +41,19 @@ services:
     expose:
       - 3000
 
+  chibisafe:
+    image: chibisafe/chibisafe:latest
+    restart: always
+    volumes:
+      - chibisafe_db:/home/node/chibisafe/database:rw
+      - chibisafe_uploads:/home/node/chibisafe/uploads:rw
+      - chibisafe_logs:/home/node/chibisafe/logs:rw
+    expose:
+      - 8000
+
 volumes:
   db:
   cache:
+  chibisafe_db:
+  chibisafe_uploads:
+  chibisafe_logs:


### PR DESCRIPTION
Closes #48 

Disadur dari repositori Chibisafe [1]:

  Chibisafe is a file uploader service written in node that aims to to be
  easy to use and easy to set up. It's easy to use, easy to deploy, free
  and open source. It accepts files, photos, documents, anything you imagine
  and gives you back a shareable link for you to send to others.

Chibisafe akan digunakan sebagai file server untuk Enpitsu.