### PR TITLE
feat: menambahkan ke miui browser ke list

### DIFF
--- a/apps/exam-web/src/Provider.tsx
+++ b/apps/exam-web/src/Provider.tsx
@@ -21,6 +21,7 @@ const userOS = parser.getOS();
 
 const enforceChromeOnAndroidOnly =
   browser.name === "Samsung Internet" ||
+  browser.name === "MIUI Browser" ||
   (userOS.name === "Android" && browser.name !== "Chrome");
 const enforceLatestVersion =
   userOS.name === "Android" &&


### PR DESCRIPTION
Setelah cek vercel firewall yang baru-baru ini di kasih aksesnya secara free ke semua vercel tier list, ada fitur yang ternyata cocok buat cek user agent yang ngunjungin website kita secara realtime. Ketemu lah dua string yang cukup tricky.

1. `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/112.0.5615.136 Safari/534.24 XiaoMi/MiuiBrowser/14.10.1-gn` 
2. `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/112.0.5615.136 Safari/534.24 XiaoMi/MiuiBrowser/14.9.1-gn`

Sebagai konteks tambahan, ini setelah di cek di websitenya [UAParser](https://uaparser.js.org), ternyata cuman detect browser tanpa sistem operasi, dimana hal ini ga bakalan trigger logic enforce chromenya.

![image](https://github.com/reacto11mecha/enpitsu/assets/48118327/07110c53-0cb1-4568-a610-18f35d3fb253)
Cek https://uaparser.js.org/?ua=Mozilla/5.0%20(X11;%20Linux%20x86_64)%20AppleWebKit/534.24%20(KHTML,%20like%20Gecko)%20Chrome/112.0.5615.136%20Safari/534.24%20XiaoMi/MiuiBrowser/14.10.1-gn

Ini setelah download mi browser, ngecek pake hape sendiri
`Mozilla/5.0 (Linux; U; Android 11; en-us; SM-A022F Build/RP1A.200720.012) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/112.0.5615.136 Mobile Safari/537.36 XiaoMi/MiuiBrowser/14.10.1-gn`

![image](https://github.com/reacto11mecha/enpitsu/assets/48118327/e1e3705d-2106-44aa-9959-a97f3998012d)
https://uaparser.js.org/?ua=Mozilla/5.0%20(Linux;%20U;%20Android%2011;%20en-us;%20SM-A022F%20Build/RP1A.200720.012)%20AppleWebKit/537.36%20(KHTML,%20like%20Gecko)%20Version/4.0%20Chrome/112.0.5615.136%20Mobile%20Safari/537.36%20XiaoMi/MiuiBrowser/14.10.1-gn

Dan di confirm dengan ngisi constructor [`UAParser`](https://github.com/reacto11mecha/enpitsu/blob/43785d11cfd14701e2b0e69e82225274c3e2bcf5/apps/exam-web/src/Provider.tsx#L17) dengan string nomor 1 sama 2 itu ga ketahan pengecekan.